### PR TITLE
PS-2036 Add getBranchClientIfAvailable method

### DIFF
--- a/src/ClientWrapper.php
+++ b/src/ClientWrapper.php
@@ -10,11 +10,14 @@ use Psr\Log\LoggerInterface;
 
 class ClientWrapper
 {
+    const BRANCH_UNINITIALIZED = null;
+    const BRANCH_MAIN = '';
+
     /** @var Client */
     private $client;
 
-    /** @var string */
-    private $branchId = null;
+    /** @var null|string */
+    private $branchId;
 
     /** @var BranchAwareClient */
     private $branchClient;
@@ -25,8 +28,12 @@ class ClientWrapper
     /** @var ?LoggerInterface */
     private $logger;
 
-    public function __construct(Client $storageClient, $pollDelayFunction, $logger, $branchId = null)
-    {
+    public function __construct(
+        Client $storageClient,
+        $pollDelayFunction,
+        $logger,
+        $branchId = self::BRANCH_UNINITIALIZED
+    ) {
         $this->client = $storageClient;
         $this->pollDelayFunction = $pollDelayFunction;
         $this->logger = $logger;
@@ -35,7 +42,7 @@ class ClientWrapper
 
     public function setBranchId($branchId)
     {
-        if ($this->branchId !== null) {
+        if ($this->branchId !== self::BRANCH_UNINITIALIZED) {
             throw new \LogicException('Branch can only be set once.');
         }
         $this->branchId = $branchId;
@@ -102,12 +109,12 @@ class ClientWrapper
     public function hasBranch()
     {
         $this->validateSelf();
-        return $this->branchId !== '';
+        return $this->branchId !== self::BRANCH_MAIN;
     }
 
     private function validateSelf()
     {
-        if ($this->branchId === null) {
+        if ($this->branchId === self::BRANCH_UNINITIALIZED) {
             throw new \LogicException('Wrapper not initialized properly.');
         }
     }

--- a/src/ClientWrapper.php
+++ b/src/ClientWrapper.php
@@ -68,6 +68,20 @@ class ClientWrapper
         return $this->branchClient;
     }
 
+    /**
+     * Returns branchClient if a branch was configured and basicClient otherwise.
+     *
+     * @return Client
+     */
+    public function getBranchClientIfAvailable()
+    {
+        if ($this->hasBranch()) {
+            return $this->getBranchClient();
+        }
+
+        return $this->getBasicClient();
+    }
+
     public function getBranchId()
     {
         $this->validateSelf();

--- a/tests/ClientWrapperTest.php
+++ b/tests/ClientWrapperTest.php
@@ -141,4 +141,20 @@ class ClientWrapperTest extends TestCase
         self::assertSame($branchId, $clientWrapper->getBranchId());
         self::assertSame('dev-123', $clientWrapper->getBranchName());
     }
+
+    public function testGetBranchClientIfAvailableWithNoBranchConfigured()
+    {
+        $client = $this->getClient();
+        $clientWrapper = new ClientWrapper($client, null, null, '');
+
+        self::assertSame($client, $clientWrapper->getBranchClientIfAvailable());
+    }
+
+    public function testGetBranchClientIfAvailableWithBranchConfigured()
+    {
+        $client = $this->getClient();
+        $clientWrapper = new ClientWrapper($client, null, null, 'test');
+
+        self::assertInstanceOf(BranchAwareClient::class, $clientWrapper->getBranchClientIfAvailable());
+    }
 }

--- a/tests/ClientWrapperTest.php
+++ b/tests/ClientWrapperTest.php
@@ -61,8 +61,8 @@ class ClientWrapperTest extends TestCase
     public function testSetBranchNoBranch()
     {
         $clientWrapper = new ClientWrapper($this->getClient(), null, null);
-        $clientWrapper->setBranchId('');
-        self::assertSame('', $clientWrapper->getBranchId());
+        $clientWrapper->setBranchId(ClientWrapper::BRANCH_MAIN);
+        self::assertSame(ClientWrapper::BRANCH_MAIN, $clientWrapper->getBranchId());
         self::assertInstanceOf(BranchAwareClient::class, $clientWrapper->getBranchClient());
         self::assertFalse($clientWrapper->hasBranch());
         self::assertNull($clientWrapper->getBranchName());
@@ -145,7 +145,7 @@ class ClientWrapperTest extends TestCase
     public function testGetBranchClientIfAvailableWithNoBranchConfigured()
     {
         $client = $this->getClient();
-        $clientWrapper = new ClientWrapper($client, null, null, '');
+        $clientWrapper = new ClientWrapper($client, null, null, ClientWrapper::BRANCH_MAIN);
 
         self::assertSame($client, $clientWrapper->getBranchClientIfAvailable());
     }


### PR DESCRIPTION
https://keboola.atlassian.net/browse/PS-2036

Jako bonus jsem pridal konstanty, ktere IMHO aspon trochu objasnuji situaci kolem pouzivani prazdneho stringu jako branch ID.