### PR TITLE
SOX-133 Allow extra ClientOptions

### DIFF
--- a/src/Factory/StorageClientRequestFactory.php
+++ b/src/Factory/StorageClientRequestFactory.php
@@ -49,11 +49,16 @@ class StorageClientRequestFactory implements StorageClientFactoryInterface
         return $runId;
     }
 
-    public function createClientWrapper(Request $request): ClientWrapper
+    public function createClientWrapper(Request $request, ?ClientOptions $clientOptions = null): ClientWrapper
     {
         $options = clone $this->clientOptions;
+        if ($clientOptions) {
+            $options->addValuesFrom($clientOptions);
+        }
+
         $options->setToken($this->getTokenFromRequest($request));
         $options->setRunId($this->getRunId($request, $options));
+
         return new ClientWrapper($options);
     }
 

--- a/tests/Factory/StorageClientRequestFactoryTest.php
+++ b/tests/Factory/StorageClientRequestFactoryTest.php
@@ -107,6 +107,17 @@ class StorageClientRequestFactoryTest extends TestCase
         self::assertStringStartsWith('123', (string) $clientWrapper->getClientOptionsReadOnly()->getRunId());
     }
 
+    public function testExtraClientOptions(): void
+    {
+        $request = new Request([], [], [], [], [], [
+            self::TOKEN_HEADER => $_SERVER['TEST_STORAGE_API_TOKEN'],
+        ]);
+        $factory = new StorageClientRequestFactory(new ClientOptions($_SERVER['TEST_STORAGE_API_URL']));
+        $clientWrapper = $factory->createClientWrapper($request, new ClientOptions(branchId: '1234'));
+
+        self::assertSame('1234', $clientWrapper->getClientOptionsReadOnly()->getBranchId());
+    }
+
     public function testGetClientOptions(): void
     {
         $factory = new StorageClientRequestFactory(new ClientOptions('http://foo'));


### PR DESCRIPTION
https://keboola.atlassian.net/browse/SOX-133

Pridana moznost predat extra `clientOptions` kdyz se vytvari client pres `StorageClientRequestFactory`. Je potreba aby se klientovi v DataLoader API dalo nastavit `useBranchClient` option (https://github.com/keboola/data-loader-api/blob/69e6e6f0eede6cf0fb3a356d7abd8d2db6438170/src/Controller/BaseControllerWithLog.php#L61)