### PR TITLE
refactor: hasBranch -> isDevelopmentBranch, getBranchId() and getBran…

### DIFF
--- a/src/ClientWrapper.php
+++ b/src/ClientWrapper.php
@@ -42,7 +42,7 @@ class ClientWrapper
     {
         if (empty($this->branchClient)) {
             $this->branchClient = new BranchAwareClient(
-                (string) $this->getBranchId(),
+                $this->getBranchId(),
                 $this->clientOptions->getClientConstructOptions(),
             );
             $this->branchClient->setRunId($this->clientOptions->getRunId());
@@ -53,10 +53,8 @@ class ClientWrapper
 
     /**
      * Returns branchClient if useBranchStorage flag is configured
-     *
-     * @return Client|BranchAwareClient
      */
-    public function getTableAndFileStorageClient(): Client
+    public function getTableAndFileStorageClient(): Client|BranchAwareClient
     {
         if ($this->clientOptions->useBranchStorage()) {
             return $this->getBranchClient();
@@ -64,24 +62,13 @@ class ClientWrapper
         return $this->getBasicClient();
     }
 
-    /**
-     * Returns branchClient if a branch was configured and basicClient otherwise.
-     *
-     * @return Client|BranchAwareClient
-     * @deprecated Use getBranchClient for all endpoints that support branches.
-     */
-    public function getBranchClientIfAvailable(): Client
-    {
-        return $this->getBranchClient();
-    }
-
-    public function getBranchId(): ?string
+    public function getBranchId(): string
     {
         $this->resolveBranchId();
         return $this->branchId;
     }
 
-    public function getBranchName(): ?string
+    public function getBranchName(): string
     {
         $this->resolveBranchId();
         return $this->branchName;
@@ -91,7 +78,7 @@ class ClientWrapper
      * Returns true if the configured branch is NON-default. Returns false for the
      *  default/main/production branch.
      */
-    public function hasBranch(): bool
+    public function isDevelopmentBranch(): bool
     {
         $this->resolveBranchId();
         return !$this->isDefaultBranch;

--- a/tests/ClientWrapperTest.php
+++ b/tests/ClientWrapperTest.php
@@ -11,7 +11,6 @@ use Keboola\StorageApi\DevBranches;
 use Keboola\StorageApi\Options\BackendConfiguration;
 use Keboola\StorageApiBranch\ClientWrapper;
 use Keboola\StorageApiBranch\Factory\ClientOptions;
-use LogicException;
 use PHPUnit\Framework\TestCase;
 
 class ClientWrapperTest extends TestCase
@@ -30,9 +29,8 @@ class ClientWrapperTest extends TestCase
             (string) $branchId,
         ));
         self::assertInstanceOf(Client::class, $clientWrapper->getBasicClient());
-        self::assertInstanceOf(BranchAwareClient::class, $clientWrapper->getBranchClientIfAvailable());
         self::assertInstanceOf(BranchAwareClient::class, $clientWrapper->getBranchClient());
-        self::assertTrue($clientWrapper->hasBranch());
+        self::assertTrue($clientWrapper->isDevelopmentBranch());
         self::assertSame((string) $branchId, $clientWrapper->getBranchId());
         self::assertFalse($clientWrapper->isDefaultBranch());
 
@@ -59,8 +57,7 @@ class ClientWrapperTest extends TestCase
             null
         ));
         self::assertInstanceOf(Client::class, $clientWrapper->getBasicClient());
-        self::assertInstanceOf(Client::class, $clientWrapper->getBranchClientIfAvailable());
-        self::assertFalse($clientWrapper->hasBranch());
+        self::assertFalse($clientWrapper->isDevelopmentBranch());
         self::assertSame('Main', $clientWrapper->getBranchName());
         self::assertSame((string) $expectedId, $clientWrapper->getBranchId());
         self::assertTrue($clientWrapper->isDefaultBranch());
@@ -86,9 +83,8 @@ class ClientWrapperTest extends TestCase
             ClientWrapper::BRANCH_DEFAULT
         ));
         self::assertInstanceOf(Client::class, $clientWrapper->getBasicClient());
-        self::assertInstanceOf(BranchAwareClient::class, $clientWrapper->getBranchClientIfAvailable());
         self::assertInstanceOf(BranchAwareClient::class, $clientWrapper->getBranchClient());
-        self::assertFalse($clientWrapper->hasBranch());
+        self::assertFalse($clientWrapper->isDevelopmentBranch());
         self::assertSame('Main', $clientWrapper->getBranchName());
         self::assertSame((string) $expectedId, $clientWrapper->getBranchId());
     }
@@ -209,10 +205,9 @@ class ClientWrapperTest extends TestCase
             useBranchStorage: $useBranchStorage,
         ));
         self::assertInstanceOf(Client::class, $clientWrapper->getBasicClient());
-        self::assertInstanceOf(BranchAwareClient::class, $clientWrapper->getBranchClientIfAvailable());
         self::assertInstanceOf(BranchAwareClient::class, $clientWrapper->getBranchClient());
         self::assertInstanceOf($expectedClassName, $clientWrapper->getTableAndFileStorageClient());
-        self::assertFalse($clientWrapper->hasBranch());
+        self::assertFalse($clientWrapper->isDevelopmentBranch());
     }
 
     public function useBranchStorageDataProvider(): Generator
@@ -240,8 +235,7 @@ class ClientWrapperTest extends TestCase
             useBranchStorage: true,
         ));
         self::assertInstanceOf(Client::class, $clientWrapper->getBasicClient());
-        self::assertInstanceOf(Client::class, $clientWrapper->getBranchClientIfAvailable());
-        self::assertFalse($clientWrapper->hasBranch());
+        self::assertFalse($clientWrapper->isDevelopmentBranch());
         self::assertSame('Main', $clientWrapper->getBranchName());
         self::assertInstanceOf(Client::class, $clientWrapper->getTableAndFileStorageClient());
     }


### PR DESCRIPTION
…chName() returns always string