### PR TITLE
chore: Allow keboola/storage-api-client:^16

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,7 @@
     "require": {
         "php": ">=8.2",
         "ext-json": "*",
-        "keboola/storage-api-client": "^15.3",
+        "keboola/storage-api-client": "^15.3|^16.0",
         "symfony/http-foundation": "^5.2|^6.0|^7.0",
         "symfony/validator": "^5.2|^6.0|^7.0"
     },


### PR DESCRIPTION
https://keboola.atlassian.net/browse/PST-883

Potrebuju updatnout `service-container` na `keboola/storage-api-client:^16` (https://github.com/keboola/job-queue/pull/510) a k tomu potrebuju, aby i wrapper to dovoloval.

Z changelogu (https://github.com/keboola/storage-api-php-client/releases/tag/v16.0.0) BC pro verzi 16 bylo odstraneni stare `shareBucket` meotdy, nahrazeni za `shareOrganizationBucket`, ktera se tu nijak primo nevyuziva, takze by to IMHO melo byt safe.