### PR TITLE
build: PST-2371 allow keboola/storage-api-client:^17

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,7 @@
     "require": {
         "php": ">=8.2",
         "ext-json": "*",
-        "keboola/storage-api-client": "^15.3|^16.0",
+        "keboola/storage-api-client": "^15.3|^16.0|^17.0",
         "symfony/http-foundation": "^5.2|^6.0|^7.0",
         "symfony/validator": "^5.2|^6.0|^7.0"
     },


### PR DESCRIPTION
https://keboola.atlassian.net/browse/PST-2471

Potrebuju updatnout storage-api-client na verzi 17.0 v sandboxes, aby to šlo je potřeba udělat povolení i zde.
Changlelog říká že se mazali věci kolem tabulek s konfigurací: https://github.com/keboola/storage-api-php-client/pull/1466 , to by snad neměl být problém.