### PR TITLE
chore: Allow keboola/storage-api-client:^18

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,7 @@
     "require": {
         "php": ">=8.2",
         "ext-json": "*",
-        "keboola/storage-api-client": "^15.3|^16.0|^17.0",
+        "keboola/storage-api-client": "^15.3|^16.0|^17.0|^18.0",
         "symfony/http-foundation": "^5.2|^6.0|^7.0",
         "symfony/validator": "^5.2|^6.0|^7.0"
     },


### PR DESCRIPTION
https://keboola.atlassian.net/browse/PAT-255

Povoleni usage `keboola/storage-api-client:^18`. BC break je v metodach na sharing buckety, ktery se tu nijak nevyuzivaji.