### PR TITLE
feat(AJDA-2160): add Bearer token authentication support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,7 @@
     "require": {
         "php": ">=8.2",
         "ext-json": "*",
-        "keboola/storage-api-client": "^15.3|^16.0|^17.0|^18.0",
+        "keboola/storage-api-client": "^18.6",
         "symfony/http-foundation": "^5.2|^6.0|^7.0",
         "symfony/validator": "^5.2|^6.0|^7.0"
     },

--- a/src/Factory/AuthType.php
+++ b/src/Factory/AuthType.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Keboola\StorageApiBranch\Factory;
+
+use Keboola\StorageApi\Client;
+
+enum AuthType: string
+{
+    case STORAGE_TOKEN = Client::AUTH_TYPE_STORAGE_TOKEN;
+    case BEARER = Client::AUTH_TYPE_BEARER;
+}

--- a/src/Factory/ClientOptions.php
+++ b/src/Factory/ClientOptions.php
@@ -29,6 +29,7 @@ class ClientOptions
         private ?BackendConfiguration $backendConfiguration = null,
         private ?bool $useBranchStorage = null,
         private ?bool $retryOnMaintenance = null,
+        private ?string $authType = null,
     ) {
         $this->setUrl($url); // call to validate URL
     }
@@ -45,6 +46,7 @@ class ClientOptions
             'awsDebug' => $this->getAwsDebug(),
             'logger' => $this->getLogger(),
             'jobPollRetryDelay' => $this->getJobPollRetryDelay(),
+            'authType' => $this->getAuthType(),
         ];
     }
 
@@ -64,6 +66,7 @@ class ClientOptions
         $this->runIdGenerator = $clientOptions->getRunIdGenerator() ?? $this->runIdGenerator;
         $this->backendConfiguration = $clientOptions->getBackendConfiguration() ?? $this->backendConfiguration;
         $this->useBranchStorage = $clientOptions->useBranchStorage() ?? $this->useBranchStorage;
+        $this->authType = $clientOptions->getAuthType() ?? $this->authType;
     }
 
     public function setUrl(?string $url): ClientOptions
@@ -226,5 +229,16 @@ class ClientOptions
     public function setRetryOnMaintenance(?bool $retryOnMaintenance): void
     {
         $this->retryOnMaintenance = $retryOnMaintenance;
+    }
+
+    public function getAuthType(): ?string
+    {
+        return $this->authType;
+    }
+
+    public function setAuthType(?string $authType): ClientOptions
+    {
+        $this->authType = $authType;
+        return $this;
     }
 }

--- a/src/Factory/ClientOptions.php
+++ b/src/Factory/ClientOptions.php
@@ -29,7 +29,7 @@ class ClientOptions
         private ?BackendConfiguration $backendConfiguration = null,
         private ?bool $useBranchStorage = null,
         private ?bool $retryOnMaintenance = null,
-        private ?string $authType = null,
+        private ?AuthType $authType = null,
     ) {
         $this->setUrl($url); // call to validate URL
     }
@@ -46,7 +46,7 @@ class ClientOptions
             'awsDebug' => $this->getAwsDebug(),
             'logger' => $this->getLogger(),
             'jobPollRetryDelay' => $this->getJobPollRetryDelay(),
-            'authType' => $this->getAuthType(),
+            'authType' => $this->getAuthType()?->value,
         ];
     }
 
@@ -231,12 +231,12 @@ class ClientOptions
         $this->retryOnMaintenance = $retryOnMaintenance;
     }
 
-    public function getAuthType(): ?string
+    public function getAuthType(): ?AuthType
     {
         return $this->authType;
     }
 
-    public function setAuthType(?string $authType): ClientOptions
+    public function setAuthType(?AuthType $authType): ClientOptions
     {
         $this->authType = $authType;
         return $this;

--- a/src/Factory/StorageClientRequestFactory.php
+++ b/src/Factory/StorageClientRequestFactory.php
@@ -23,30 +23,28 @@ class StorageClientRequestFactory implements StorageClientFactoryInterface
         $this->clientOptions->addValuesFrom($clientOptions);
     }
 
-    /**
-     * @return array{token: string, authType: AuthType}
-     */
-    private function getTokenFromRequest(Request $request): array
+    private function getTokenFromRequest(Request $request): ClientOptions
     {
         $authHeader = $request->headers->get(self::AUTHORIZATION_HEADER);
         if ($authHeader !== null && str_starts_with($authHeader, self::BEARER_PREFIX)) {
-            return [
-                'token' => substr($authHeader, strlen(self::BEARER_PREFIX)),
-                'authType' => AuthType::BEARER,
-            ];
+            $token = substr($authHeader, strlen(self::BEARER_PREFIX));
+            if ($token === '') {
+                throw new ClientException(
+                    'Bearer token in Authorization header is empty.',
+                    401,
+                );
+            }
+            return new ClientOptions(token: $token, authType: AuthType::BEARER);
         }
 
         $token = (string) $request->headers->get(self::TOKEN_HEADER);
         if ($token !== '') {
-            return [
-                'token' => $token,
-                'authType' => AuthType::STORAGE_TOKEN,
-            ];
+            return new ClientOptions(token: $token, authType: AuthType::STORAGE_TOKEN);
         }
 
         throw new ClientException(
             sprintf(
-                'Storage API token must be supplied in %s header or %s header.',
+                'Token must be supplied via %s: Bearer header or %s header.',
                 self::AUTHORIZATION_HEADER,
                 self::TOKEN_HEADER,
             ),
@@ -75,9 +73,7 @@ class StorageClientRequestFactory implements StorageClientFactoryInterface
             $options->addValuesFrom($clientOptions);
         }
 
-        $tokenData = $this->getTokenFromRequest($request);
-        $options->setToken($tokenData['token']);
-        $options->setAuthType($tokenData['authType']);
+        $options->addValuesFrom($this->getTokenFromRequest($request));
         $options->setRunId($this->getRunId($request, $options));
 
         return new ClientWrapper($options);

--- a/src/Factory/StorageClientRequestFactory.php
+++ b/src/Factory/StorageClientRequestFactory.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Keboola\StorageApiBranch\Factory;
 
-use Keboola\StorageApi\Client;
 use Keboola\StorageApi\ClientException;
 use Keboola\StorageApiBranch\ClientWrapper;
 use Symfony\Component\HttpFoundation\Request;
@@ -25,7 +24,7 @@ class StorageClientRequestFactory implements StorageClientFactoryInterface
     }
 
     /**
-     * @return array{token: string, authType: string}
+     * @return array{token: string, authType: AuthType}
      */
     private function getTokenFromRequest(Request $request): array
     {
@@ -33,7 +32,7 @@ class StorageClientRequestFactory implements StorageClientFactoryInterface
         if ($authHeader !== null && str_starts_with($authHeader, self::BEARER_PREFIX)) {
             return [
                 'token' => substr($authHeader, strlen(self::BEARER_PREFIX)),
-                'authType' => Client::AUTH_TYPE_BEARER,
+                'authType' => AuthType::BEARER,
             ];
         }
 
@@ -41,7 +40,7 @@ class StorageClientRequestFactory implements StorageClientFactoryInterface
         if ($token !== '') {
             return [
                 'token' => $token,
-                'authType' => Client::AUTH_TYPE_STORAGE_TOKEN,
+                'authType' => AuthType::STORAGE_TOKEN,
             ];
         }
 

--- a/src/Factory/StorageClientRequestFactory.php
+++ b/src/Factory/StorageClientRequestFactory.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Keboola\StorageApiBranch\Factory;
 
+use Keboola\StorageApi\Client;
 use Keboola\StorageApi\ClientException;
 use Keboola\StorageApiBranch\ClientWrapper;
 use Symfony\Component\HttpFoundation\Request;
@@ -12,6 +13,8 @@ class StorageClientRequestFactory implements StorageClientFactoryInterface
 {
     public const TOKEN_HEADER = 'X-StorageApi-Token';
     public const RUN_ID_HEADER = 'X-KBC-RunId';
+    private const AUTHORIZATION_HEADER = 'Authorization';
+    private const BEARER_PREFIX = 'Bearer ';
 
     private ClientOptions $clientOptions;
 
@@ -21,18 +24,35 @@ class StorageClientRequestFactory implements StorageClientFactoryInterface
         $this->clientOptions->addValuesFrom($clientOptions);
     }
 
-    private function getTokenFromRequest(Request $request): string
+    /**
+     * @return array{token: string, authType: string}
+     */
+    private function getTokenFromRequest(Request $request): array
     {
-        $token = (string) $request->headers->get(self::TOKEN_HEADER);
-
-        if ($token === '') {
-            throw new ClientException(
-                sprintf('Storage API token must be supplied in %s header.', self::TOKEN_HEADER),
-                401,
-            );
+        $authHeader = $request->headers->get(self::AUTHORIZATION_HEADER);
+        if ($authHeader !== null && str_starts_with($authHeader, self::BEARER_PREFIX)) {
+            return [
+                'token' => substr($authHeader, strlen(self::BEARER_PREFIX)),
+                'authType' => Client::AUTH_TYPE_BEARER,
+            ];
         }
 
-        return $token;
+        $token = (string) $request->headers->get(self::TOKEN_HEADER);
+        if ($token !== '') {
+            return [
+                'token' => $token,
+                'authType' => Client::AUTH_TYPE_STORAGE_TOKEN,
+            ];
+        }
+
+        throw new ClientException(
+            sprintf(
+                'Storage API token must be supplied in %s header or %s header.',
+                self::AUTHORIZATION_HEADER,
+                self::TOKEN_HEADER,
+            ),
+            401,
+        );
     }
 
     private function getRunId(Request $request, ClientOptions $options): string
@@ -56,7 +76,9 @@ class StorageClientRequestFactory implements StorageClientFactoryInterface
             $options->addValuesFrom($clientOptions);
         }
 
-        $options->setToken($this->getTokenFromRequest($request));
+        $tokenData = $this->getTokenFromRequest($request);
+        $options->setToken($tokenData['token']);
+        $options->setAuthType($tokenData['authType']);
         $options->setRunId($this->getRunId($request, $options));
 
         return new ClientWrapper($options);

--- a/tests/Factory/ClientOptionsTest.php
+++ b/tests/Factory/ClientOptionsTest.php
@@ -254,6 +254,7 @@ class ClientOptionsTest extends TestCase
                 'awsDebug' => false,
                 'logger' => $logger,
                 'jobPollRetryDelay' => $retryFunction,
+                'authType' => null,
             ],
             $clientOptions->getClientConstructOptions(),
         );

--- a/tests/Factory/StorageClientRequestFactoryTest.php
+++ b/tests/Factory/StorageClientRequestFactoryTest.php
@@ -4,12 +4,8 @@ declare(strict_types=1);
 
 namespace Keboola\StorageApiBranch\Tests\Factory;
 
-use GuzzleHttp\Handler\MockHandler;
-use GuzzleHttp\HandlerStack;
-use GuzzleHttp\Middleware;
-use GuzzleHttp\Psr7\Response;
-use Keboola\StorageApi\Client;
 use Keboola\StorageApi\ClientException;
+use Keboola\StorageApiBranch\Factory\AuthType;
 use Keboola\StorageApiBranch\Factory\ClientOptions;
 use Keboola\StorageApiBranch\Factory\StorageClientRequestFactory;
 use PHPUnit\Framework\TestCase;
@@ -158,7 +154,7 @@ class StorageClientRequestFactoryTest extends TestCase
         $clientWrapper = $factory->createClientWrapper($request);
 
         self::assertSame($testToken, $clientWrapper->getClientOptionsReadOnly()->getToken());
-        self::assertSame(Client::AUTH_TYPE_BEARER, $clientWrapper->getClientOptionsReadOnly()->getAuthType());
+        self::assertSame(AuthType::BEARER, $clientWrapper->getClientOptionsReadOnly()->getAuthType());
     }
 
     public function testFactoryWithStorageToken(): void
@@ -172,7 +168,7 @@ class StorageClientRequestFactoryTest extends TestCase
 
         self::assertSame($_SERVER['TEST_STORAGE_API_TOKEN'], $clientWrapper->getClientOptionsReadOnly()->getToken());
         self::assertSame(
-            Client::AUTH_TYPE_STORAGE_TOKEN,
+            AuthType::STORAGE_TOKEN,
             $clientWrapper->getClientOptionsReadOnly()->getAuthType(),
         );
     }
@@ -189,7 +185,7 @@ class StorageClientRequestFactoryTest extends TestCase
         $clientWrapper = $factory->createClientWrapper($request);
 
         self::assertSame($bearerToken, $clientWrapper->getClientOptionsReadOnly()->getToken());
-        self::assertSame(Client::AUTH_TYPE_BEARER, $clientWrapper->getClientOptionsReadOnly()->getAuthType());
+        self::assertSame(AuthType::BEARER, $clientWrapper->getClientOptionsReadOnly()->getAuthType());
     }
 
     public function testFactoryWithInvalidAuthorizationHeader(): void
@@ -219,6 +215,6 @@ class StorageClientRequestFactoryTest extends TestCase
         $clientWrapper = $factory->createClientWrapper($request);
 
         self::assertSame('', $clientWrapper->getClientOptionsReadOnly()->getToken());
-        self::assertSame(Client::AUTH_TYPE_BEARER, $clientWrapper->getClientOptionsReadOnly()->getAuthType());
+        self::assertSame(AuthType::BEARER, $clientWrapper->getClientOptionsReadOnly()->getAuthType());
     }
 }

--- a/tests/Factory/StorageClientRequestFactoryTest.php
+++ b/tests/Factory/StorageClientRequestFactoryTest.php
@@ -4,6 +4,11 @@ declare(strict_types=1);
 
 namespace Keboola\StorageApiBranch\Tests\Factory;
 
+use GuzzleHttp\Handler\MockHandler;
+use GuzzleHttp\HandlerStack;
+use GuzzleHttp\Middleware;
+use GuzzleHttp\Psr7\Response;
+use Keboola\StorageApi\Client;
 use Keboola\StorageApi\ClientException;
 use Keboola\StorageApiBranch\Factory\ClientOptions;
 use Keboola\StorageApiBranch\Factory\StorageClientRequestFactory;
@@ -14,6 +19,7 @@ class StorageClientRequestFactoryTest extends TestCase
 {
     private const TOKEN_HEADER = 'HTTP_X_STORAGEAPI_TOKEN';
     private const RUN_ID_HEADER = 'HTTP_X_KBC_RUNID';
+    private const AUTHORIZATION_HEADER = 'HTTP_AUTHORIZATION';
 
     /**
      * @dataProvider provideEmptyTokenHeader
@@ -139,5 +145,80 @@ class StorageClientRequestFactoryTest extends TestCase
         $factory->createClientWrapper($request);
         self::assertNull($options->getToken());
         self::assertNull($factory->getClientOptionsReadOnly()->getToken());
+    }
+
+    public function testFactoryWithBearerToken(): void
+    {
+        $testToken = 'test-bearer-token-12345';
+        $request = new Request([], [], [], [], [], [
+            self::AUTHORIZATION_HEADER => 'Bearer ' . $testToken,
+        ]);
+
+        $factory = new StorageClientRequestFactory(new ClientOptions($_SERVER['TEST_STORAGE_API_URL']));
+        $clientWrapper = $factory->createClientWrapper($request);
+
+        self::assertSame($testToken, $clientWrapper->getClientOptionsReadOnly()->getToken());
+        self::assertSame(Client::AUTH_TYPE_BEARER, $clientWrapper->getClientOptionsReadOnly()->getAuthType());
+    }
+
+    public function testFactoryWithStorageToken(): void
+    {
+        $request = new Request([], [], [], [], [], [
+            self::TOKEN_HEADER => $_SERVER['TEST_STORAGE_API_TOKEN'],
+        ]);
+
+        $factory = new StorageClientRequestFactory(new ClientOptions($_SERVER['TEST_STORAGE_API_URL']));
+        $clientWrapper = $factory->createClientWrapper($request);
+
+        self::assertSame($_SERVER['TEST_STORAGE_API_TOKEN'], $clientWrapper->getClientOptionsReadOnly()->getToken());
+        self::assertSame(
+            Client::AUTH_TYPE_STORAGE_TOKEN,
+            $clientWrapper->getClientOptionsReadOnly()->getAuthType(),
+        );
+    }
+
+    public function testFactoryBearerTokenHasPriorityOverStorageToken(): void
+    {
+        $bearerToken = 'bearer-token-12345';
+        $request = new Request([], [], [], [], [], [
+            self::AUTHORIZATION_HEADER => 'Bearer ' . $bearerToken,
+            self::TOKEN_HEADER => $_SERVER['TEST_STORAGE_API_TOKEN'],
+        ]);
+
+        $factory = new StorageClientRequestFactory(new ClientOptions($_SERVER['TEST_STORAGE_API_URL']));
+        $clientWrapper = $factory->createClientWrapper($request);
+
+        self::assertSame($bearerToken, $clientWrapper->getClientOptionsReadOnly()->getToken());
+        self::assertSame(Client::AUTH_TYPE_BEARER, $clientWrapper->getClientOptionsReadOnly()->getAuthType());
+    }
+
+    public function testFactoryWithInvalidAuthorizationHeader(): void
+    {
+        $request = new Request([], [], [], [], [], [
+            self::AUTHORIZATION_HEADER => 'Basic sometoken',
+        ]);
+
+        $factory = new StorageClientRequestFactory(new ClientOptions());
+
+        $this->expectException(ClientException::class);
+        $this->expectExceptionMessage(
+            'Storage API token must be supplied in Authorization header or X-StorageApi-Token header.',
+        );
+        $this->expectExceptionCode(401);
+
+        $factory->createClientWrapper($request);
+    }
+
+    public function testFactoryWithEmptyBearerToken(): void
+    {
+        $request = new Request([], [], [], [], [], [
+            self::AUTHORIZATION_HEADER => 'Bearer ',
+        ]);
+
+        $factory = new StorageClientRequestFactory(new ClientOptions($_SERVER['TEST_STORAGE_API_URL']));
+        $clientWrapper = $factory->createClientWrapper($request);
+
+        self::assertSame('', $clientWrapper->getClientOptionsReadOnly()->getToken());
+        self::assertSame(Client::AUTH_TYPE_BEARER, $clientWrapper->getClientOptionsReadOnly()->getAuthType());
     }
 }

--- a/tests/Factory/StorageClientRequestFactoryTest.php
+++ b/tests/Factory/StorageClientRequestFactoryTest.php
@@ -27,7 +27,7 @@ class StorageClientRequestFactoryTest extends TestCase
 
         $this->expectException(ClientException::class);
         $this->expectExceptionMessage(
-            'Storage API token must be supplied in Authorization header or X-StorageApi-Token header.',
+            'Token must be supplied via Authorization: Bearer header or X-StorageApi-Token header.',
         );
         $this->expectExceptionCode(401);
 
@@ -198,7 +198,7 @@ class StorageClientRequestFactoryTest extends TestCase
 
         $this->expectException(ClientException::class);
         $this->expectExceptionMessage(
-            'Storage API token must be supplied in Authorization header or X-StorageApi-Token header.',
+            'Token must be supplied via Authorization: Bearer header or X-StorageApi-Token header.',
         );
         $this->expectExceptionCode(401);
 
@@ -211,10 +211,12 @@ class StorageClientRequestFactoryTest extends TestCase
             self::AUTHORIZATION_HEADER => 'Bearer ',
         ]);
 
-        $factory = new StorageClientRequestFactory(new ClientOptions($_SERVER['TEST_STORAGE_API_URL']));
-        $clientWrapper = $factory->createClientWrapper($request);
+        $factory = new StorageClientRequestFactory(new ClientOptions());
 
-        self::assertSame('', $clientWrapper->getClientOptionsReadOnly()->getToken());
-        self::assertSame(AuthType::BEARER, $clientWrapper->getClientOptionsReadOnly()->getAuthType());
+        $this->expectException(ClientException::class);
+        $this->expectExceptionMessage('Bearer token in Authorization header is empty.');
+        $this->expectExceptionCode(401);
+
+        $factory->createClientWrapper($request);
     }
 }

--- a/tests/Factory/StorageClientRequestFactoryTest.php
+++ b/tests/Factory/StorageClientRequestFactoryTest.php
@@ -24,7 +24,9 @@ class StorageClientRequestFactoryTest extends TestCase
         $factory = new StorageClientRequestFactory(new ClientOptions());
 
         $this->expectException(ClientException::class);
-        $this->expectExceptionMessage('Storage API token must be supplied in X-StorageApi-Token header.');
+        $this->expectExceptionMessage(
+            'Storage API token must be supplied in Authorization header or X-StorageApi-Token header.',
+        );
         $this->expectExceptionCode(401);
 
         $factory->createClientWrapper($request);


### PR DESCRIPTION
## Summary

This PR adds support for OAuth Bearer token authentication via the standard `Authorization: Bearer <token>` header, while maintaining backward compatibility with the existing `X-StorageApi-Token` header.

**Key changes:**
- Updated `keboola/storage-api-client` dependency to `^18.6` (required for `AUTH_TYPE_BEARER` support)
- Added new `AuthType` backed enum for type-safe authentication type handling
- Added `authType` property to `ClientOptions` with getter/setter and inclusion in `getClientConstructOptions()` and `addValuesFrom()`
- Refactored `StorageClientRequestFactory::getTokenFromRequest()` to return `ClientOptions` and use `addValuesFrom()` for cleaner code
- Added validation to reject empty Bearer tokens with a specific error message
- Updated error messages to clarify which token type goes in which header

## Review & Testing Checklist for Human

- [ ] **Verify dependency constraint change is acceptable**: The change from `^15.3|^16.0|^17.0|^18.0` to `^18.6` is a breaking change for downstream projects using older storage-api-client versions. Confirm this is intentional.
- [ ] **Test Bearer token authentication end-to-end**: Create a request with `Authorization: Bearer <token>` header and verify it authenticates correctly against the Storage API
- [ ] **Test backward compatibility**: Verify existing `X-StorageApi-Token` header authentication still works
- [ ] **Verify header precedence**: When both headers are present, `Authorization` takes precedence - confirm this is the desired behavior
- [ ] **Verify empty Bearer token rejection**: Sending `Authorization: Bearer ` (with empty token) should now return a 401 error

### Notes

- Linear ticket: AJDA-2160
- This unblocks AI OAuth authentication flows (AI-2276)
- Requested by: Ondřej Jodas (@ondrajodas)
- Link to Devin run: https://app.devin.ai/sessions/94c117e3e9d64c48bac52d85d57e9a37

## Release Notes
**Justification, description**

Adds Bearer token authentication support to enable OAuth-based authentication flows. The wrapper library now supports both `Authorization: Bearer <token>` and `X-StorageApi-Token` headers.

**Plans for Customer Communication**

N/A

**Impact Analysis**

Breaking change: Minimum required version of `keboola/storage-api-client` is now ^18.6

**Deployment Plan**

N/A

**Rollback Plan**

N/A

**Post-Release Support Plan**

N/A