### PR TITLE
PAT-1902 Carry auth type on StorageApiToken (deprecation runway)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -29,6 +29,7 @@
         "php": ">=8.2",
         "ext-json": "*",
         "keboola/storage-api-client": "^18.6",
+        "symfony/deprecation-contracts": "^2.5|^3.0",
         "symfony/http-foundation": "^5.2|^6.0|^7.0",
         "symfony/validator": "^5.2|^6.0|^7.0"
     },

--- a/src/ClientWrapper.php
+++ b/src/ClientWrapper.php
@@ -8,6 +8,7 @@ use Keboola\StorageApi\BranchAwareClient;
 use Keboola\StorageApi\Client;
 use Keboola\StorageApi\ClientException;
 use Keboola\StorageApi\DevBranches;
+use Keboola\StorageApiBranch\Factory\AuthType;
 use Keboola\StorageApiBranch\Factory\ClientOptions;
 
 class ClientWrapper
@@ -130,6 +131,7 @@ class ClientWrapper
             $this->storageToken = new StorageApiToken(
                 $this->getBranchClient()->verifyToken(),
                 $this->getBranchClient()->getTokenString(),
+                $this->clientOptions->getAuthType() ?? AuthType::STORAGE_TOKEN,
             );
         }
         return $this->storageToken;

--- a/src/Factory/ClientOptions.php
+++ b/src/Factory/ClientOptions.php
@@ -11,6 +11,7 @@ use Psr\Log\LoggerInterface;
 use SensitiveParameter;
 use Symfony\Component\Validator\Constraints\Url;
 use Symfony\Component\Validator\Validation;
+use function trigger_deprecation;
 
 class ClientOptions
 {
@@ -36,6 +37,16 @@ class ClientOptions
 
     public function getClientConstructOptions(): array
     {
+        if ($this->token !== null && $this->authType === null) {
+            trigger_deprecation(
+                'keboola/storage-api-php-client-branch-wrapper',
+                '6.8',
+                'Building a Storage client from ClientOptions with a token but without an authType is '
+                . 'deprecated; it will be required in 7.0. Set authType explicitly (AuthType::STORAGE_TOKEN '
+                . 'for legacy Storage tokens, AuthType::BEARER for OAuth bearer tokens).',
+            );
+        }
+
         return [
             'url' => $this->getUrl(),
             'userAgent' => $this->getUserAgent(),

--- a/src/Factory/StorageClientPlainFactory.php
+++ b/src/Factory/StorageClientPlainFactory.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Keboola\StorageApiBranch\Factory;
 
 use Keboola\StorageApiBranch\ClientWrapper;
+use Keboola\StorageApiBranch\StorageApiToken;
 
 class StorageClientPlainFactory implements StorageClientFactoryInterface
 {
@@ -25,5 +26,25 @@ class StorageClientPlainFactory implements StorageClientFactoryInterface
         $options = clone $this->clientOptions;
         $options->addValuesFrom($clientOptions);
         return new ClientWrapper($options);
+    }
+
+    /**
+     * Builds a wrapper authenticating as the given token, honoring its {@see StorageApiToken::getTokenType()}
+     * (so an OAuth bearer token is sent with the bearer scheme, a Storage token as X-StorageApi-Token).
+     * Extra per-call options (e.g. branchId) are merged over the token-derived ones.
+     */
+    public function createClientWrapperForToken(
+        StorageApiToken $token,
+        ?ClientOptions $clientOptions = null,
+    ): ClientWrapper {
+        $options = new ClientOptions(
+            token: $token->getTokenValue(),
+            authType: $token->getTokenType(),
+        );
+        if ($clientOptions !== null) {
+            $options->addValuesFrom($clientOptions);
+        }
+
+        return $this->createClientWrapper($options);
     }
 }

--- a/src/StorageApiToken.php
+++ b/src/StorageApiToken.php
@@ -4,14 +4,41 @@ declare(strict_types=1);
 
 namespace Keboola\StorageApiBranch;
 
+use Keboola\StorageApiBranch\Factory\AuthType;
 use SensitiveParameter;
+use function trigger_deprecation;
 
 class StorageApiToken
 {
+    private readonly AuthType $tokenType;
+
     public function __construct(
         private readonly array $tokenInfo,
         #[SensitiveParameter] private readonly string $tokenValue,
+        ?AuthType $tokenType = null,
     ) {
+        if ($tokenType === null) {
+            trigger_deprecation(
+                'keboola/storage-api-php-client-branch-wrapper',
+                '6.8',
+                'Constructing %s without the $tokenType argument is deprecated; it will be required in 7.0. '
+                . 'Pass AuthType::STORAGE_TOKEN explicitly for legacy Storage tokens.',
+                self::class,
+            );
+            $tokenType = AuthType::STORAGE_TOKEN;
+        }
+
+        $this->tokenType = $tokenType;
+    }
+
+    /**
+     * Auth scheme the token authenticates with: {@see AuthType::STORAGE_TOKEN} (sent as the
+     * X-StorageApi-Token header) or {@see AuthType::BEARER} (sent as an Authorization: Bearer
+     * header, e.g. OAuth tokens). Lets callers build a Storage client with the matching scheme.
+     */
+    public function getTokenType(): AuthType
+    {
+        return $this->tokenType;
     }
 
     public function getTokenInfo(): array

--- a/tests/Factory/ClientOptionsTest.php
+++ b/tests/Factory/ClientOptionsTest.php
@@ -6,6 +6,7 @@ namespace Keboola\StorageApiBranch\Tests\Factory;
 
 use Keboola\StorageApi\ClientException;
 use Keboola\StorageApi\Options\BackendConfiguration;
+use Keboola\StorageApiBranch\Factory\AuthType;
 use Keboola\StorageApiBranch\Factory\ClientOptions;
 use PHPUnit\Framework\TestCase;
 use Psr\Log\NullLogger;
@@ -242,6 +243,7 @@ class ClientOptionsTest extends TestCase
             $backendConfiguration,
             false,
             false,
+            AuthType::STORAGE_TOKEN,
         );
         self::assertEquals(
             [
@@ -254,9 +256,79 @@ class ClientOptionsTest extends TestCase
                 'awsDebug' => false,
                 'logger' => $logger,
                 'jobPollRetryDelay' => $retryFunction,
-                'authType' => null,
+                'authType' => AuthType::STORAGE_TOKEN->value,
             ],
             $clientOptions->getClientConstructOptions(),
         );
+    }
+
+    public function testGetClientConstructOptionsWithoutAuthTypeTriggersDeprecation(): void
+    {
+        $clientOptions = new ClientOptions(url: 'http://dummy', token: 'token');
+
+        $deprecations = [];
+        set_error_handler(
+            static function (int $errno, string $errstr) use (&$deprecations): bool {
+                $deprecations[] = $errstr;
+                return true;
+            },
+            E_USER_DEPRECATED,
+        );
+
+        try {
+            $constructOptions = $clientOptions->getClientConstructOptions();
+        } finally {
+            restore_error_handler();
+        }
+
+        // legacy default preserved: a null authType lets the Client fall back to the Storage token
+        self::assertNull($constructOptions['authType']);
+        self::assertCount(1, $deprecations);
+        self::assertStringContainsString('authType', $deprecations[0]);
+    }
+
+    public function testGetClientConstructOptionsWithAuthTypeDoesNotTriggerDeprecation(): void
+    {
+        $clientOptions = new ClientOptions(url: 'http://dummy', token: 'token', authType: AuthType::BEARER);
+
+        $deprecations = [];
+        set_error_handler(
+            static function (int $errno, string $errstr) use (&$deprecations): bool {
+                $deprecations[] = $errstr;
+                return true;
+            },
+            E_USER_DEPRECATED,
+        );
+
+        try {
+            $constructOptions = $clientOptions->getClientConstructOptions();
+        } finally {
+            restore_error_handler();
+        }
+
+        self::assertSame(AuthType::BEARER->value, $constructOptions['authType']);
+        self::assertCount(0, $deprecations);
+    }
+
+    public function testGetClientConstructOptionsWithoutTokenDoesNotTriggerDeprecation(): void
+    {
+        $clientOptions = new ClientOptions(url: 'http://dummy');
+
+        $deprecations = [];
+        set_error_handler(
+            static function (int $errno, string $errstr) use (&$deprecations): bool {
+                $deprecations[] = $errstr;
+                return true;
+            },
+            E_USER_DEPRECATED,
+        );
+
+        try {
+            $clientOptions->getClientConstructOptions();
+        } finally {
+            restore_error_handler();
+        }
+
+        self::assertCount(0, $deprecations);
     }
 }

--- a/tests/Factory/StorageClientPlainFactoryTest.php
+++ b/tests/Factory/StorageClientPlainFactoryTest.php
@@ -4,8 +4,10 @@ declare(strict_types=1);
 
 namespace Keboola\StorageApiBranch\Tests\Factory;
 
+use Keboola\StorageApiBranch\Factory\AuthType;
 use Keboola\StorageApiBranch\Factory\ClientOptions;
 use Keboola\StorageApiBranch\Factory\StorageClientPlainFactory;
+use Keboola\StorageApiBranch\StorageApiToken;
 use PHPUnit\Framework\TestCase;
 
 class StorageClientPlainFactoryTest extends TestCase
@@ -35,5 +37,20 @@ class StorageClientPlainFactoryTest extends TestCase
         $factory->createClientWrapper(new ClientOptions(null, $_SERVER['TEST_STORAGE_API_TOKEN']));
         self::assertNull($options->getToken());
         self::assertNull($factory->getClientOptionsReadOnly()->getToken());
+    }
+
+    public function testCreateClientWrapperForTokenUsesTokenValueAndAuthType(): void
+    {
+        $factory = new StorageClientPlainFactory(new ClientOptions('http://foo'));
+        $token = new StorageApiToken(['id' => '1'], 'oauth-value', AuthType::BEARER);
+
+        $options = $factory
+            ->createClientWrapperForToken($token, new ClientOptions(branchId: '123'))
+            ->getClientOptionsReadOnly();
+
+        self::assertSame('oauth-value', $options->getToken());
+        self::assertSame(AuthType::BEARER, $options->getAuthType());
+        self::assertSame('123', $options->getBranchId());
+        self::assertSame('http://foo', $options->getUrl());
     }
 }

--- a/tests/StorageApiTokenTest.php
+++ b/tests/StorageApiTokenTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Keboola\StorageApiBranch\Tests;
 
+use Keboola\StorageApiBranch\Factory\AuthType;
 use Keboola\StorageApiBranch\StorageApiToken;
 use PHPUnit\Framework\TestCase;
 
@@ -236,5 +237,41 @@ class StorageApiTokenTest extends TestCase
         );
 
         self::assertNull($token->getSamlUserId());
+    }
+
+    public function testExplicitBearerTokenType(): void
+    {
+        $token = new StorageApiToken(['id' => '1'], 'oauth-value', AuthType::BEARER);
+
+        self::assertSame(AuthType::BEARER, $token->getTokenType());
+    }
+
+    public function testExplicitStorageTokenType(): void
+    {
+        $token = new StorageApiToken(['id' => '1'], 'legacy-value', AuthType::STORAGE_TOKEN);
+
+        self::assertSame(AuthType::STORAGE_TOKEN, $token->getTokenType());
+    }
+
+    public function testMissingTokenTypeDefaultsToStorageTokenAndTriggersDeprecation(): void
+    {
+        $deprecations = [];
+        set_error_handler(
+            static function (int $errno, string $errstr) use (&$deprecations): bool {
+                $deprecations[] = $errstr;
+                return true;
+            },
+            E_USER_DEPRECATED,
+        );
+
+        try {
+            $token = new StorageApiToken(['id' => '1'], 'legacy-value');
+        } finally {
+            restore_error_handler();
+        }
+
+        self::assertSame(AuthType::STORAGE_TOKEN, $token->getTokenType());
+        self::assertCount(1, $deprecations);
+        self::assertStringContainsString('tokenType', $deprecations[0]);
     }
 }


### PR DESCRIPTION
## Release Notes
https://linear.app/keboola/issue/PAT-1902/api-bundle-proper-oauth-token-support

> [!NOTE]
> Se zavedenim "Oauth tokenu" pribyl `authType` atribut na Storage clientovi, ktery rika, jestli to, co se pouziva jako `token` value je klasicky Storage token nebo Bearer. To znamena, ze nam i pres `StorageApiToken` object uz nestaci predavat jen value tokenu, ale potrebujeme i type.

Code that builds a Storage client from a token via `ClientOptions(token: $token->getTokenValue(), …)` had no way to know the token's auth scheme, so an OAuth bearer token got sent as `X-StorageApi-Token` and rejected. This makes the token carry its auth type, so callers can build a correctly-authenticated client from a token alone.

`StorageApiToken` gains an optional `AuthType $tokenType` (+ `getTokenType()`). `ClientWrapper::getToken()` populates it from the wrapper's `ClientOptions`, so any token obtained from a wrapper is self-describing (including tokens minted internally). `StorageClientPlainFactory::createClientWrapperForToken()` then builds a wrapper authenticating as a given token in one call, honoring its auth type — so consumers stop re-plumbing the scheme by hand.

Omitting the constructor argument is deprecated (via `symfony/deprecation-contracts`) and will be required in the next major; it falls back to `AuthType::STORAGE_TOKEN`, so every existing two-argument construction keeps working.

Key changes:
* `StorageApiToken`: optional `AuthType $tokenType` + `getTokenType()`; `trigger_deprecation` when omitted, defaulting to `STORAGE_TOKEN`.
* `ClientWrapper::getToken()`: carries the wrapper's resolved auth type onto the token.
* `StorageClientPlainFactory::createClientWrapperForToken(StorageApiToken, ?ClientOptions)`.
* Adds `symfony/deprecation-contracts` (previously only transitively present).

First adopters: `keboola/api-bundle` (PAT-1902) and `sandboxes-service`, which use `createClientWrapperForToken()` to authenticate OAuth bearer tokens end-to-end.

## Plans for customer communication
None.

## Impact analysis
No end-user impact. Backward-compatible, additive change: the new constructor argument is optional and defaults to the previous behavior (`STORAGE_TOKEN`). The only behavioral change is a deprecation notice when the argument is omitted — consumers whose test suites fail on deprecations must pass the argument (or relax their threshold) before upgrading.

## Change type
New feature

## Justification
Fleet-wide OAuth/bearer token support (PAT-1902) with a backward-compatible migration path toward making the auth type explicit.

## Deployment
Merge & tag release.

## Rollback plan
Revert of this PR.

## Post release support plan
None.
